### PR TITLE
fix: change deprecated treesitter query method get_query to get

### DIFF
--- a/lua/nvim-lsp-extras/treesitter_hover/treesitter.lua
+++ b/lua/nvim-lsp-extras/treesitter_hover/treesitter.lua
@@ -26,7 +26,10 @@ function M.highlight(buf, ns, range, lang)
             return
         end
 
-        local highlighter_query = vim.treesitter.query.get(tree:lang(), "highlights")
+        -- TODO: adjust after neovim 10 become dependency
+        local highlighter_query = vim.treesitter.query.get
+          and vim.treesitter.query.get(tree:lang(), "highlights")
+           or vim.treesitter.query.get_query(tree:lang(), "highlights")
 
         -- Some injected languages may not have highlight queries.
         if not highlighter_query then

--- a/lua/nvim-lsp-extras/treesitter_hover/treesitter.lua
+++ b/lua/nvim-lsp-extras/treesitter_hover/treesitter.lua
@@ -26,7 +26,7 @@ function M.highlight(buf, ns, range, lang)
             return
         end
 
-        local highlighter_query = vim.treesitter.query.get_query(tree:lang(), "highlights")
+        local highlighter_query = vim.treesitter.query.get(tree:lang(), "highlights")
 
         -- Some injected languages may not have highlight queries.
         if not highlighter_query then


### PR DESCRIPTION
fix warning of (will be) deprecated treesitter query method

- from `get_query` to be `get`

<img width="760" alt="Screenshot 2023-03-27 at 23 28 54" src="https://user-images.githubusercontent.com/25895873/228004529-77703e86-e076-4020-93fe-765a8aef7d8b.png">
